### PR TITLE
Ensure copyright and license notice is embedded in libcuda_verify_ed25519.a

### DIFF
--- a/src/cuda-ecc-ed25119/ed25519.h
+++ b/src/cuda-ecc-ed25119/ed25519.h
@@ -58,6 +58,7 @@ void ED25519_DECLSPEC ed25519_key_exchange(unsigned char *shared_secret, const u
 void ED25519_DECLSPEC ed25519_free_gpu_mem();
 void ED25519_DECLSPEC ed25519_set_verbose(bool val);
 
+const char* ED25519_DECLSPEC ed25519_license();
 
 #ifdef __cplusplus
 }

--- a/src/cuda-ecc-ed25119/verify.cu
+++ b/src/cuda-ecc-ed25119/verify.cu
@@ -276,3 +276,10 @@ void ed25519_free_gpu_mem() {
         }
     }
 }
+
+// Ensure copyright and license notice is embedded in the binary
+const char* ed25519_license() {
+   return "Copyright (c) 2018 Solana Labs, Inc. "
+	"License AGPLv3: GNU Affero General Public License "
+	"<https://www.gnu.org/licenses/agpl-3.0.html>";
+}


### PR DESCRIPTION
Just a little more CYA (or is it COA...) since we reference `libcuda_verify_ed25519.a` from the main Solana repo and we don't want anybody to be confused that it might be Apache 2.0

```sh
mvines@sagan:~/wool$ strings ./src/cuda-ecc-ed25119/release/libcuda_verify_ed25519.a | grep License
Copyright (c) 2018 Solana Labs, Inc. License AGPLv3: GNU Affero General Public License <https://www.gnu.org/licenses/agpl-3.0.html>
```