### PR TITLE
Switch to shared object for cuda-crypt library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install:
     ./src/gf-complete/src/.libs/libgf_complete.so \
     ./src/jerasure/src/.libs/libJerasure.so \
     ./src/cuda-ecc-ed25119/release/libcuda_verify_ed25519.a \
-    ./src/cuda-crypt/release/libcuda-crypt.a \
+    ./src/cuda-crypt/release/libcuda-crypt.so \
     ./src/cpu-crypt/release/libcpu-crypt.a \
     $(DESTDIR)
 	ln -sfT libJerasure.so $(DESTDIR)/libJerasure.so.2

--- a/src/cuda-crypt/Makefile
+++ b/src/cuda-crypt/Makefile
@@ -14,11 +14,14 @@ $V/aes_cbc.o: aes_cbc.cu aes_core.cu modes_lcl.h common.cu
 	@mkdir -p $(@D)
 	$(NVCC) -rdc=true $(CFLAGS) -c $< -o $@
 
-$V/lib$(LIB).a: $V/aes_cbc.o $V/chacha_cbc.o
-	$(NVCC) -Xcompiler "-fPIC" --lib --output-file $@ $^
+$V/chacha-dlink.o: $V/chacha_cbc.o $V/aes_cbc.o
+	$(NVCC) -Xcompiler "-fPIC" --gpu-architecture=compute_61 --device-link $^ --output-file $@
 
-$V/$(TEST_BIN): test.cu $V/lib$(LIB).a
-	$(NVCC) $(CFLAGS) $^ -o $@
+$V/lib$(LIB).so: $V/chacha-dlink.o $V/chacha_cbc.o $V/aes_cbc.o
+	$(NVCC) -Xcompiler "-fPIC" --shared --output-file $@ $^
+
+$V/$(TEST_BIN): test.cu $V/lib$(LIB).so
+	$(NVCC) $(CFLAGS) -L$V -l$(LIB) $< -o $@
 
 .PHONY:clean
 clean:


### PR DESCRIPTION
Some symbols from the nvidia driver clash between this and the ed25519 library
when both are static libs.