### PR TITLE
Take message_size from argument and not hardcoded struct size

### DIFF
--- a/src/cuda-ecc-ed25519/ed25519.h
+++ b/src/cuda-ecc-ed25519/ed25519.h
@@ -30,23 +30,9 @@ int ED25519_DECLSPEC ed25519_create_seed(unsigned char *seed);
 #define SEED_SIZE 32
 #define SCALAR_SIZE 32
 #define SIG_SIZE 64
-#define PACKET_SIZE 512
 
 typedef struct {
-    size_t size;
-    uint64_t num_retransmits;
-    uint16_t addr[8];
-    uint16_t port;
-    bool v6;
-} streamer_Meta;
-
-typedef struct {
-    uint8_t data[PACKET_SIZE];
-    streamer_Meta meta;
-} streamer_Packet;
-
-typedef struct {
-    streamer_Packet* elems;
+    uint8_t* elems;
     uint32_t num;
 } gpu_Elems;
 

--- a/src/cuda-ecc-ed25519/main.cu
+++ b/src/cuda-ecc-ed25519/main.cu
@@ -10,6 +10,21 @@
 
 #define LOG(...) if (verbose) { printf(__VA_ARGS__); }
 
+#define PACKET_SIZE 512
+
+typedef struct {
+    size_t size;
+    uint64_t num_retransmits;
+    uint16_t addr[8];
+    uint16_t port;
+    bool v6;
+} streamer_Meta;
+
+typedef struct {
+    uint8_t data[PACKET_SIZE];
+    streamer_Meta meta;
+} streamer_Packet;
+
 bool verbose = false;
 
 void print_dwords(unsigned char* ptr, int size) {
@@ -105,7 +120,7 @@ int main(int argc, const char* argv[]) {
     std::vector<gpu_Elems> elems_h = std::vector<gpu_Elems>(num_elems);
     for (int i = 0; i < num_elems; i++) {
         elems_h[i].num = num_signatures;
-        elems_h[i].elems = &packets_h[0];
+        elems_h[i].elems = (uint8_t*)&packets_h[0];
     }
 
     LOG("initing signatures..\n");


### PR DESCRIPTION
Allows rust side to configure any packet size they like without
updating cuda lib.