### PR TITLE
Use arrays of offsets instead of fixed offsets

### DIFF
--- a/src/cuda-ecc-ed25519/ed25519.h
+++ b/src/cuda-ecc-ed25519/ed25519.h
@@ -39,7 +39,7 @@ typedef struct {
 void ED25519_DECLSPEC ed25519_create_keypair(unsigned char *public_key, unsigned char *private_key, const unsigned char *seed);
 void ED25519_DECLSPEC ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key, const unsigned char *private_key);
 int ED25519_DECLSPEC ed25519_verify(const unsigned char *signature, const unsigned char *message, uint32_t message_len, const unsigned char *public_key);
-void ED25519_DECLSPEC ed25519_verify_many(const gpu_Elems* elems, uint32_t num, uint32_t message_size, uint32_t public_key_offset, uint32_t signature_offset, uint32_t message_start_offset, uint32_t message_len, uint8_t* out);
+void ED25519_DECLSPEC ed25519_verify_many(const gpu_Elems* elems, uint32_t num_elems, uint32_t message_size, uint32_t total_packets, uint32_t total_signatures, const uint32_t* message_lens, const uint32_t* public_key_offset, const uint32_t* signature_offset, const uint32_t* message_start_offset, uint8_t* out);
 void ED25519_DECLSPEC ed25519_add_scalar(unsigned char *public_key, unsigned char *private_key, const unsigned char *scalar);
 void ED25519_DECLSPEC ed25519_key_exchange(unsigned char *shared_secret, const unsigned char *public_key, const unsigned char *private_key);
 void ED25519_DECLSPEC ed25519_free_gpu_mem();


### PR DESCRIPTION
Allows for multiple signatures per packet and gives
more flexibility to the calling code.