### PR TITLE
Use separate streams per GPU context to get more kernel overlap

### DIFF
--- a/src/cuda-ecc-ed25519/ed25519.h
+++ b/src/cuda-ecc-ed25519/ed25519.h
@@ -39,7 +39,7 @@ typedef struct {
 void ED25519_DECLSPEC ed25519_create_keypair(unsigned char *public_key, unsigned char *private_key, const unsigned char *seed);
 void ED25519_DECLSPEC ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key, const unsigned char *private_key);
 int ED25519_DECLSPEC ed25519_verify(const unsigned char *signature, const unsigned char *message, uint32_t message_len, const unsigned char *public_key);
-void ED25519_DECLSPEC ed25519_verify_many(const gpu_Elems* elems, uint32_t num_elems, uint32_t message_size, uint32_t total_packets, uint32_t total_signatures, const uint32_t* message_lens, const uint32_t* public_key_offset, const uint32_t* signature_offset, const uint32_t* message_start_offset, uint8_t* out);
+void ED25519_DECLSPEC ed25519_verify_many(const gpu_Elems* elems, uint32_t num_elems, uint32_t message_size, uint32_t total_packets, uint32_t total_signatures, const uint32_t* message_lens, const uint32_t* public_key_offset, const uint32_t* signature_offset, const uint32_t* message_start_offset, uint8_t* out, uint8_t use_non_default_stream);
 void ED25519_DECLSPEC ed25519_add_scalar(unsigned char *public_key, unsigned char *private_key, const unsigned char *scalar);
 void ED25519_DECLSPEC ed25519_key_exchange(unsigned char *shared_secret, const unsigned char *public_key, const unsigned char *private_key);
 void ED25519_DECLSPEC ed25519_free_gpu_mem();

--- a/src/cuda-ecc-ed25519/main.cu
+++ b/src/cuda-ecc-ed25519/main.cu
@@ -4,11 +4,10 @@
 #include <assert.h>
 #include <vector>
 #include <pthread.h>
+#include "gpu_common.h"
 
 #define USE_CLOCK_GETTIME
 #include "perftime.h"
-
-#define LOG(...) if (verbose) { printf(__VA_ARGS__); }
 
 #define PACKET_SIZE 512
 
@@ -24,8 +23,6 @@ typedef struct {
     uint8_t data[PACKET_SIZE];
     streamer_Meta meta;
 } streamer_Packet;
-
-bool verbose = false;
 
 void print_dwords(unsigned char* ptr, int size) {
     for (int j = 0; j < (size)/(int)sizeof(uint32_t); j++) {
@@ -50,25 +47,50 @@ typedef struct {
     uint32_t* signature_offsets;
     uint32_t* message_start_offsets;
     uint8_t* out_h;
+    int num_iterations;
+    uint8_t use_non_default_stream;
 } verify_ctx_t;
 
 static void* verify_proc(void* ctx) {
     verify_ctx_t* vctx = (verify_ctx_t*)ctx;
-    ed25519_verify_many(&vctx->elems_h[0],
-                        vctx->num_elems,
-                        sizeof(streamer_Packet),
-                        vctx->total_packets,
-                        vctx->total_signatures,
-                        vctx->message_lens,
-                        vctx->public_key_offsets,
-                        vctx->signature_offsets,
-                        vctx->message_start_offsets,
-                        vctx->out_h);
+    for (int i = 0; i < vctx->num_iterations; i++) {
+        ed25519_verify_many(&vctx->elems_h[0],
+                            vctx->num_elems,
+                            sizeof(streamer_Packet),
+                            vctx->total_packets,
+                            vctx->total_signatures,
+                            vctx->message_lens,
+                            vctx->public_key_offsets,
+                            vctx->signature_offsets,
+                            vctx->message_start_offsets,
+                            vctx->out_h,
+                            vctx->use_non_default_stream);
+    }
     return NULL;
+}
+
+const static bool USE_CUDA_ALLOC = true;
+
+template<typename T> static void ed25519_alloc(T** ptr, size_t num) {
+    if (USE_CUDA_ALLOC) {
+        CUDA_CHK(cudaMallocHost(ptr, sizeof(T) * num));
+    } else {
+        *ptr = (T*)calloc(sizeof(T), num);
+    }
+}
+
+static void ed25519_free(void* ptr) {
+    if (USE_CUDA_ALLOC) {
+        CUDA_CHK(cudaFreeHost(ptr));
+    } else {
+        free(ptr);
+    }
+
 }
 
 int main(int argc, const char* argv[]) {
     int arg;
+    bool verbose = false;
     for (arg = 1; arg < argc; arg++) {
         if (0 == strcmp(argv[arg], "-v")) {
             verbose = true;
@@ -77,8 +99,8 @@ int main(int argc, const char* argv[]) {
         }
     }
 
-    if ((argc - arg) != 4) {
-        printf("usage: %s [-v] <num_signatures> <num_elems> <num_sigs_per_packet> <num_threads>\n", argv[0]);
+    if ((argc - arg) != 6) {
+        printf("usage: %s [-v] <num_signatures> <num_elems> <num_sigs_per_packet> <num_threads> <num_iterations> <use_non_default_stream>\n", argv[0]);
         return 1;
     }
 
@@ -108,6 +130,18 @@ int main(int argc, const char* argv[]) {
         return 1;
     }
 
+    int num_iterations = strtol(argv[arg++], NULL, 10);
+    if (num_iterations <= 0) {
+        printf("num_iterations should be > 0! %d\n", num_iterations);
+        return 1;
+    }
+
+    uint8_t use_non_default_stream = (uint8_t)strtol(argv[arg++], NULL, 10);
+    if (use_non_default_stream != 0 && use_non_default_stream != 1) {
+        printf("non_default_stream should be 0 or 1! %d\n", use_non_default_stream);
+        return 1;
+    }
+
     LOG("streamer size: %zu elems size: %zu\n", sizeof(streamer_Packet), sizeof(gpu_Elems));
 
     std::vector<verify_ctx_t> vctx = std::vector<verify_ctx_t>(num_threads);
@@ -119,10 +153,18 @@ int main(int argc, const char* argv[]) {
     int message_h_len = strlen((char*)message_h);
 
     uint32_t total_signatures = num_elems * num_signatures_per_elem;
-    uint32_t* message_lens = (uint32_t*)calloc(total_signatures, sizeof(uint32_t));
-    uint32_t* signature_offsets = (uint32_t*)calloc(total_signatures, sizeof(uint32_t));
-    uint32_t* public_key_offsets = (uint32_t*)calloc(total_signatures, sizeof(uint32_t));
-    uint32_t* message_start_offsets = (uint32_t*)calloc(total_signatures, sizeof(uint32_t));
+
+    uint32_t* message_lens = NULL;
+    ed25519_alloc(&message_lens, total_signatures);
+
+    uint32_t* signature_offsets = NULL;
+    ed25519_alloc(&signature_offsets, total_signatures);
+
+    uint32_t* public_key_offsets = NULL;
+    ed25519_alloc(&public_key_offsets, total_signatures);
+
+    uint32_t* message_start_offsets = NULL;
+    ed25519_alloc(&message_start_offsets, total_signatures);
 
     for (uint32_t i = 0; i < total_signatures; i++) {
         uint32_t base_offset = i * sizeof(streamer_Packet);
@@ -137,12 +179,16 @@ int main(int argc, const char* argv[]) {
         vctx[i].signature_offsets = signature_offsets;
         vctx[i].public_key_offsets = public_key_offsets;
         vctx[i].message_start_offsets = message_start_offsets;
+        vctx[i].num_iterations = num_iterations;
+        vctx[i].use_non_default_stream = use_non_default_stream;
     }
 
-    std::vector<streamer_Packet> packets_h = std::vector<streamer_Packet>(num_signatures_per_elem);
+    streamer_Packet* packets_h = NULL;
+    ed25519_alloc(&packets_h, num_signatures_per_elem);
     uint32_t total_packets = 0;
 
-    std::vector<gpu_Elems> elems_h = std::vector<gpu_Elems>(num_elems);
+    gpu_Elems* elems_h = NULL;
+    ed25519_alloc(&elems_h, num_elems);
     for (int i = 0; i < num_elems; i++) {
         elems_h[i].num = num_signatures_per_elem;
         elems_h[i].elems = (uint8_t*)&packets_h[0];
@@ -167,7 +213,7 @@ int main(int argc, const char* argv[]) {
     int out_size = total_signatures * sizeof(uint8_t);
     for (int i = 0; i < num_threads; i++) {
         vctx[i].num_elems = num_elems;
-        vctx[i].out_h = (uint8_t*)calloc(1, out_size);
+        ed25519_alloc(&vctx[i].out_h, out_size);
         vctx[i].elems_h = &elems_h[0];
         vctx[i].total_signatures = total_signatures;
         vctx[i].total_packets = total_packets;
@@ -231,7 +277,7 @@ int main(int argc, const char* argv[]) {
     }
     get_time(&end);
 
-    int total = (num_threads * total_signatures);
+    int total = (num_threads * total_signatures * num_iterations);
     double diff = get_diff(&start, &end);
     printf("time diff: %f total: %d sigs/sec: %f\n",
            diff,
@@ -251,6 +297,18 @@ int main(int argc, const char* argv[]) {
         fflush(stdout);
         assert(verify_failed == false);
     }
+
+    ed25519_free(elems_h);
+    ed25519_free(packets_h);
+    ed25519_free(message_lens);
+    ed25519_free(signature_offsets);
+    ed25519_free(public_key_offsets);
+    ed25519_free(message_start_offsets);
+    for (int thread = 0; thread < num_threads; thread++) {
+        ed25519_free(vctx[thread].out_h);
+    }
+    free(seed_h);
+    free(private_key_h);
     ed25519_free_gpu_mem();
     return 0;
 }


### PR DESCRIPTION
Improves performance for smaller kernel launches.
Also add some more options to the test program to test cudaMallocHost vs. malloc'ed memory and multiple iterations per thread to amortize the cudaMalloc initialization costs.