### PR TITLE
Build for cuda 10.0 and 10.1; Upload release tarball to github instead of S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,20 +8,20 @@ SO=so
 all: cuda_crypt
 endif
 
-MAKE_ARGS:=V=release
+V=release
 
 .PHONY:cuda_crypt
 cuda_crypt:
-	$(MAKE) $(MAKE_ARGS) -C src
+	$(MAKE) V=$(V) -C src
 
 DESTDIR ?= dist
 install:
 	mkdir -p $(DESTDIR)
 ifneq ($(OS),Darwin)
-	cp -f src/release/libcuda-crypt.a $(DESTDIR)
+	cp -f src/$(V)/libcuda-crypt.a $(DESTDIR)
 endif
 	ls -lh $(DESTDIR)
 
 .PHONY:clean
 clean:
-	$(MAKE) $(MAKE_ARGS) -C src clean
+	$(MAKE) V=$(V) -C src clean

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ install:
 	mkdir -p $(DESTDIR)
 ifneq ($(OS),Darwin)
 	cp -f src/$(V)/libcuda-crypt.a $(DESTDIR)
+	cp -f src/$(V)/libcuda-crypt.so $(DESTDIR)
 endif
 	ls -lh $(DESTDIR)
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,55 +1,49 @@
 #!/usr/bin/env bash
 set -e
-
 cd "$(dirname "$0")/.."
 
-: "${CUDA_HOME:=/usr/local/cuda-10.1}"
+source ci/env.sh
+source ci/upload-ci-artifact.sh
 
-if [[ ! -d $CUDA_HOME/lib64 ]]; then
-  echo Invalid CUDA_HOME: $CUDA_HOME
-  exit 1
-fi
+for CUDA_HOME in /usr/local/cuda-10.0 /usr/local/cuda-10.1; do
+  CUDA_HOME_BASE=$(basename $CUDA_HOME)
+  echo "--- Build: $CUDA_HOME_BASE"
+  (
+    if [[ ! -d $CUDA_HOME/lib64 ]]; then
+      echo Invalid CUDA_HOME: $CUDA_HOME
+      exit 1
+    fi
 
-export LD_LIBRARY_PATH=$CUDA_HOME/lib64
-export PATH=$PATH:$HOME/.cargo/bin/:$CUDA_HOME/bin
+    set -x
+    export LD_LIBRARY_PATH=$CUDA_HOME/lib64
+    export PATH=$PATH:$HOME/.cargo/bin/:$CUDA_HOME/bin
+    export DESTDIR=dist/$CUDA_HOME_BASE
 
-echo --- Build
+    make -j"$(nproc)"
+    make install
+    make clean
+
+    cp -vf $CUDA_HOME/version.txt "$DESTDIR"/cuda-version.txt
+  )
+done
+
+echo --- Build SGX
 (
   set -x
-  make V=release -j$(nproc)
-  make install
-
-  ci/docker-run.sh solanalabs/sgxsdk ./src/sgx-ecc-ed25519/build.sh
-  ci/docker-run.sh solanalabs/sgxsdk ./src/sgx/build.sh
-
-  cd dist
-  git rev-parse HEAD | tee solana-perf-HEAD.txt
-  echo $CUDA_HOME | tee solana-perf-CUDA_HOME.txt
-  cp -f $CUDA_HOME/version.txt cuda-version.txt
-  tar zcvf ../solana-perf.tgz *
+  ci/docker-run.sh solanalabs/sgxsdk src/sgx-ecc-ed25519/build.sh
+  ci/docker-run.sh solanalabs/sgxsdk src/sgx/build.sh
 )
 
-BRANCH=$BUILDKITE_BRANCH
-if [[ -n "$BUILDKITE_TAG" ]]; then
-  BRANCH=$BUILDKITE_TAG
-fi
+echo --- Create tarball
+(
+  set -x
+  cd dist
+  git rev-parse HEAD | tee solana-perf-HEAD.txt
+  tar zcvf ../solana-perf.tgz ./*
+)
 
-if [[ -z "$BRANCH" || $BRANCH =~ pull/* ]]; then
-  exit 0
-fi
+upload-ci-artifact solana-perf.tgz
 
-echo --- AWS S3 Store
-set -x
-
-TOOLCHAIN=x86_64-unknown-linux-gnu # TODO: Remove hard code
-
-docker run \
-  --rm \
-  --env AWS_ACCESS_KEY_ID \
-  --env AWS_SECRET_ACCESS_KEY \
-  --volume "$PWD:/solana" \
-  eremite/aws-cli:2018.12.18 \
-  /usr/bin/s3cmd --acl-public put /solana/solana-perf.tgz \
-  s3://solana-perf/$BRANCH/$TOOLCHAIN/solana-perf.tgz
-
+[[ -n $CI_TAG ]] || exit 0
+ci/upload-github-release-asset.sh solana-perf.tgz
 exit 0

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -1,0 +1,83 @@
+#
+# Normalized CI environment variables
+#
+# |source| me
+#
+
+if [[ -n $CI ]]; then
+  export CI=1
+  if [[ -n $TRAVIS ]]; then
+    export CI_BRANCH=$TRAVIS_BRANCH
+    export CI_BUILD_ID=$TRAVIS_BUILD_ID
+    export CI_COMMIT=$TRAVIS_COMMIT
+    export CI_JOB_ID=$TRAVIS_JOB_ID
+    if $TRAVIS_PULL_REQUEST; then
+      export CI_PULL_REQUEST=true
+    else
+      export CI_PULL_REQUEST=
+    fi
+    export CI_OS_NAME=$TRAVIS_OS_NAME
+    export CI_REPO_SLUG=$TRAVIS_REPO_SLUG
+    export CI_TAG=$TRAVIS_TAG
+  elif [[ -n $BUILDKITE ]]; then
+    export CI_BRANCH=$BUILDKITE_BRANCH
+    export CI_BUILD_ID=$BUILDKITE_BUILD_ID
+    export CI_COMMIT=$BUILDKITE_COMMIT
+    export CI_JOB_ID=$BUILDKITE_JOB_ID
+    # The standard BUILDKITE_PULL_REQUEST environment variable is always "false" due
+    # to how solana-ci-gate is used to trigger PR builds rather than using the
+    # standard Buildkite PR trigger.
+    if [[ $CI_BRANCH =~ pull/* ]]; then
+      export CI_PULL_REQUEST=true
+    else
+      export CI_PULL_REQUEST=
+    fi
+    export CI_OS_NAME=linux
+    export CI_REPO_SLUG=$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_SLUG
+    # TRIGGERED_BUILDKITE_TAG is a workaround to propagate BUILDKITE_TAG into
+    # the solana-secondary builder
+    if [[ -n $TRIGGERED_BUILDKITE_TAG ]]; then
+      export CI_TAG=$TRIGGERED_BUILDKITE_TAG
+    else
+      export CI_TAG=$BUILDKITE_TAG
+    fi
+  elif [[ -n $APPVEYOR ]]; then
+    export CI_BRANCH=$APPVEYOR_REPO_BRANCH
+    export CI_BUILD_ID=$APPVEYOR_BUILD_ID
+    export CI_COMMIT=$APPVEYOR_REPO_COMMIT
+    export CI_JOB_ID=$APPVEYOR_JOB_ID
+    if [[ -n $APPVEYOR_PULL_REQUEST_NUMBER ]]; then
+      export CI_PULL_REQUEST=true
+    else
+      export CI_PULL_REQUEST=
+    fi
+    if [[ $CI_LINUX = True ]]; then
+      export CI_OS_NAME=linux
+    elif [[ $CI_WINDOWS = True ]]; then
+      export CI_OS_NAME=windows
+    fi
+    export CI_REPO_SLUG=$APPVEYOR_REPO_NAME
+    export CI_TAG=$APPVEYOR_REPO_TAG_NAME
+  fi
+else
+  export CI=
+  export CI_BRANCH=
+  export CI_BUILD_ID=
+  export CI_COMMIT=
+  export CI_JOB_ID=
+  export CI_OS_NAME=
+  export CI_PULL_REQUEST=
+  export CI_REPO_SLUG=
+  export CI_TAG=
+fi
+
+cat <<EOF
+CI=$CI
+CI_BRANCH=$CI_BRANCH
+CI_BUILD_ID=$CI_BUILD_ID
+CI_COMMIT=$CI_COMMIT
+CI_JOB_ID=$CI_JOB_ID
+CI_OS_NAME=$CI_OS_NAME
+CI_PULL_REQUEST=$CI_PULL_REQUEST
+CI_TAG=$CI_TAG
+EOF

--- a/ci/upload-ci-artifact.sh
+++ b/ci/upload-ci-artifact.sh
@@ -1,0 +1,18 @@
+# |source| me
+
+upload-ci-artifact() {
+  echo "--- artifact: $1"
+  if [[ -r "$1" ]]; then
+    ls -l "$1"
+    if ${BUILDKITE:-false}; then
+      (
+        set -x
+        buildkite-agent artifact upload "$1"
+      )
+    fi
+  else
+    echo ^^^ +++
+    echo "$1 not found"
+  fi
+}
+

--- a/ci/upload-github-release-asset.sh
+++ b/ci/upload-github-release-asset.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Uploads one or more files to a github release
+#
+# Prerequisites
+# 1) GITHUB_TOKEN defined in the environment
+# 2) TAG defined in the environment
+#
+set -e
+
+if [[ -z $1 ]]; then
+  echo No files specified
+  exit 1
+fi
+
+if [[ -z $GITHUB_TOKEN ]]; then
+  echo Error: GITHUB_TOKEN not defined
+  exit 1
+fi
+
+if [[ -z $CI_TAG ]]; then
+  echo Error: CI_TAG not defined
+  exit 1
+fi
+
+if [[ -z $CI_REPO_SLUG ]]; then
+  echo Error: CI_REPO_SLUG not defined
+  exit 1
+fi
+
+releaseId=$( \
+  curl -s "https://api.github.com/repos/$CI_REPO_SLUG/releases/tags/$CI_TAG" \
+  | grep -m 1 \"id\": \
+  | sed -ne 's/^[^0-9]*\([0-9]*\),$/\1/p' \
+)
+echo "Github release id for $CI_TAG is $releaseId"
+
+for file in "$@"; do
+  echo "--- Uploading $file to tag $CI_TAG of $CI_REPO_SLUG"
+  curl \
+    --data-binary @"$file" \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Content-Type: application/octet-stream" \
+    "https://uploads.github.com/repos/$CI_REPO_SLUG/releases/$releaseId/assets?name=$(basename "$file")"
+  echo
+done
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@ CUDA_SHA256_DIR:=cuda-sha256
 
 CFLAGS+=-DENDIAN_NEUTRAL -DLTC_NO_ASM -I$(CUDA_HEADER_DIR) -I$(CUDA_SHA256_DIR)
 
-all: $V/$(CHACHA_TEST_BIN) $V/$(ECC_TEST_BIN)
+all: $V/$(CHACHA_TEST_BIN) $V/$(ECC_TEST_BIN) $(V)/lib$(LIB).so
 
 ECC_DIR:=cuda-ecc-ed25519
 VERIFY_SRCS:=$(addprefix $(ECC_DIR)/,verify.cu seed.cu sha512.cu ge.cu sc.cu fe.cu sign.cu keypair.cu common.cu ed25519.h)
@@ -55,6 +55,9 @@ $V/crypt-dlink.o: $V/chacha_cbc.o $V/aes_cbc.o $V/verify.o $V/poh_verify.o
 
 $V/lib$(LIB).a: $V/crypt-dlink.o $V/chacha_cbc.o $V/aes_cbc.o $V/verify.o $V/poh_verify.o
 	$(NVCC) -Xcompiler "-fPIC" --lib --output-file $@ $^
+
+$V/lib$(LIB).so: $V/crypt-dlink.o $V/chacha_cbc.o $V/aes_cbc.o $V/verify.o $V/poh_verify.o
+	$(NVCC) -Xcompiler "-fPIC" --lib --shared --output-file $@ $^
 
 $V/$(CHACHA_TEST_BIN): $(CHACHA_DIR)/test.cu $V/lib$(LIB).a
 	$(NVCC) $(CFLAGS) -L$V -l$(LIB) $< -o $@


### PR DESCRIPTION
1. Supporting multiple CUDA versions is nice for users.
2. Storing Github releases are free, S3 is not.