### PR TITLE
libcuda-crypt.so is now a real shared object; don't ship libcuda-crypt.a anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ DESTDIR ?= dist
 install:
 	mkdir -p $(DESTDIR)
 ifneq ($(OS),Darwin)
-	cp -f src/$(V)/libcuda-crypt.a $(DESTDIR)
 	cp -f src/$(V)/libcuda-crypt.so $(DESTDIR)
 endif
 	ls -lh $(DESTDIR)

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -5,12 +5,17 @@ cd "$(dirname "$0")/.."
 source ci/env.sh
 source ci/upload-ci-artifact.sh
 
-for CUDA_HOME in /usr/local/cuda-10.0 /usr/local/cuda-10.1; do
-  CUDA_HOME_BASE=$(basename $CUDA_HOME)
+CUDA_HOMES=(
+  /usr/local/cuda-10.0
+  /usr/local/cuda-10.1
+)
+
+for CUDA_HOME in "${CUDA_HOMES[@]}"; do
+  CUDA_HOME_BASE="$(basename "$CUDA_HOME")"
   echo "--- Build: $CUDA_HOME_BASE"
   (
     if [[ ! -d $CUDA_HOME/lib64 ]]; then
-      echo Invalid CUDA_HOME: $CUDA_HOME
+      echo "Invalid CUDA_HOME: $CUDA_HOME"
       exit 1
     fi
 
@@ -23,7 +28,7 @@ for CUDA_HOME in /usr/local/cuda-10.0 /usr/local/cuda-10.1; do
     make install
     make clean
 
-    cp -vf $CUDA_HOME/version.txt "$DESTDIR"/cuda-version.txt
+    cp -vf "$CUDA_HOME"/version.txt "$DESTDIR"/cuda-version.txt
   )
 done
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -57,7 +57,7 @@ $V/lib$(LIB).a: $V/crypt-dlink.o $V/chacha_cbc.o $V/aes_cbc.o $V/verify.o $V/poh
 	$(NVCC) -Xcompiler "-fPIC" --lib --output-file $@ $^
 
 $V/lib$(LIB).so: $V/crypt-dlink.o $V/chacha_cbc.o $V/aes_cbc.o $V/verify.o $V/poh_verify.o
-	$(NVCC) -Xcompiler "-fPIC" --lib --shared --output-file $@ $^
+	$(NVCC) -Xcompiler "-fPIC" --shared --output-file $@ $^
 
 $V/$(CHACHA_TEST_BIN): $(CHACHA_DIR)/test.cu $V/lib$(LIB).a
 	$(NVCC) $(CFLAGS) -L$V -l$(LIB) $< -o $@


### PR DESCRIPTION
Main repo needs rework to support multiple CUDA versions...