### PR TITLE
Add PoH SIMD

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -39,6 +39,12 @@ echo --- Build SGX
   ci/docker-run.sh solanalabs/sgxsdk src/sgx/build.sh
 )
 
+echo --- Build ISPC
+(
+  set -x
+  ci/docker-run.sh solanalabs/ispc src/poh-simd/build.sh
+)
+
 echo --- Create tarball
 (
   set -x

--- a/ci/docker-ispc/Dockerfile
+++ b/ci/docker-ispc/Dockerfile
@@ -1,0 +1,41 @@
+FROM buildpack-deps:stretch
+
+ARG ISPC_HOME=/usr/local/src/ispc
+ARG LLVM_HOME=/usr/local/src/llvm
+ARG LLVM_VERSION=8.0
+
+ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$ISPC_HOME/bin/bin:$PATH
+
+RUN set -x \
+ && apt-get update \
+ && apt purge -y --auto-remove cmake \
+ && apt-get install -y bison flex \
+ && wget https://cmake.org/files/v3.8/cmake-3.8.0-Linux-x86_64.sh \
+ && mkdir /opt/cmake \
+ && sh cmake-3.8.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license \
+ && ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake \
+ && rm cmake-3.8.0-Linux-x86_64.sh \
+ && cmake --version \
+ && git clone git://github.com/ispc/ispc.git $ISPC_HOME \
+ && cd $ISPC_HOME \
+ && python alloy.py -b --version=$LLVM_VERSION --git --selfbuild \
+ && rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-$LLVM_VERSION_temp $LLVM_HOME/build-$LLVM_VERSION_temp \
+ && mkdir build \
+ && cd build \
+ && echo $PATH \
+ && ls -la /usr/local/src/llvm/bin-8.0/bin \
+ && cmake -DCMAKE_INSTALL_PREFIX=$ISPC_HOME/bin -DCMAKE_CXX_COMPILER=clang++ $ISPC_HOME \
+ && make -j$(nproc) \
+ && make install \
+ && cd .. \
+ && rm -rf build \
+ && mv $LLVM_HOME/bin-$LLVM_VERSION / \
+ && rm -rf $LLVM_HOME \
+ && mkdir -p $LLVM_HOME \
+ && mv /bin-$LLVM_VERSION $LLVM_HOME \
+ && cd / \
+ && mv $ISPC_HOME/bin /ispcbin \
+ && rm -rf $ISPC_HOME \
+ && mkdir $ISPC_HOME \
+ && mv /ispcbin $ISPC_HOME/bin \
+ && ispc --version

--- a/src/poh-simd/Makefile
+++ b/src/poh-simd/Makefile
@@ -1,0 +1,43 @@
+CC=ispc
+ISPC_FLAGS := -O2 --pic -I.
+DEPS := sha256.h
+
+ISPC_OBJ := ispcobj
+ISPC_C_Objects := $(ISPC_OBJ)/poh-verify-sse2.o \
+    		  $(ISPC_OBJ)/poh-verify-sse4.o \
+		  $(ISPC_OBJ)/poh-verify-avx1.o \
+		  $(ISPC_OBJ)/poh-verify-avx2.o \
+		  $(ISPC_OBJ)/poh-verify-avx512skx.o
+
+OUT ?= libs
+
+.PHONY: all run
+all: $(OUT)/libpoh-simd.a
+run: all
+
+$(ISPC_OBJ)/poh-verify-sse2.o: poh-verify.ipsc $(DEPS)
+	@mkdir -p $(ISPC_OBJ)
+	$(CC) --target=sse2-i32x4 -DNAME_SUFFIX=sse2 $(ISPC_FLAGS) $< -o $@
+
+$(ISPC_OBJ)/poh-verify-sse4.o: poh-verify.ipsc $(DEPS)
+	@mkdir -p $(ISPC_OBJ)
+	$(CC) --target=sse4-i32x4 -DNAME_SUFFIX=sse4 $(ISPC_FLAGS) $< -o $@
+
+$(ISPC_OBJ)/poh-verify-avx1.o: poh-verify.ipsc $(DEPS)
+	@mkdir -p $(ISPC_OBJ)
+	$(CC) --target=avx1-i32x8 -DNAME_SUFFIX=avx1 $(ISPC_FLAGS) $< -o $@
+
+$(ISPC_OBJ)/poh-verify-avx2.o: poh-verify.ipsc $(DEPS)
+	@mkdir -p $(ISPC_OBJ)
+	$(CC) --target=avx2-i32x8 -DNAME_SUFFIX=avx2 $(ISPC_FLAGS) $< -o $@
+
+$(ISPC_OBJ)/poh-verify-avx512skx.o: poh-verify.ipsc $(DEPS)
+	@mkdir -p $(ISPC_OBJ)
+	$(CC) --target=avx512skx-i32x16 -DNAME_SUFFIX=avx512skx $(ISPC_FLAGS) $< -o $@
+
+$(OUT)/libpoh-simd.a: $(ISPC_C_Objects)
+	@mkdir -p $(OUT)
+	ar rcs $@ $^
+
+clean:
+	@rm -rf $(ISPC_OBJ) $(OUT)

--- a/src/poh-simd/build.sh
+++ b/src/poh-simd/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+pwd=$PWD
+cd "$(dirname "$0")"
+
+echo --- Build
+(
+  set -x
+  make OUT="$pwd"/dist
+)
+

--- a/src/poh-simd/poh-verify.ipsc
+++ b/src/poh-simd/poh-verify.ipsc
@@ -1,0 +1,169 @@
+#include "sha256.h"
+
+#define MAKE_FN_NAME(x) export void  poh_verify_many_simd_ ## x (uniform u8 hashes[], uniform const unsigned int64 num_hashes_arr[])
+#define FUNCTION_NAME(signal) MAKE_FN_NAME(signal)
+
+FUNCTION_NAME(NAME_SUFFIX)
+{
+    foreach(i = 0 ... programCount) {
+        u8* hash = &hashes[i * SHA256_BLOCK_SIZE];
+        varying u32 s[8];
+        varying u32 w[64];
+        varying u32 T0;
+        varying u32 T1;
+
+        // Load words
+        memcpy(w, hash, SHA256_BLOCK_SIZE);
+
+        if (num_hashes_arr[i] > 0) {
+            for (int j = 0; j < num_hashes_arr[i]; j++) {
+                s[0] = 0x6a09e667;
+                s[1] = 0xbb67ae85;
+                s[2] = 0x3c6ef372;
+                s[3] = 0xa54ff53a;
+                s[4] = 0x510e527f;
+                s[5] = 0x9b05688c;
+                s[6] = 0x1f83d9ab;
+                s[7] = 0x5be0cd19;
+
+                w[8] = 0x80000000;
+                w[9] = 0;
+                w[10] = 0;
+                w[11] = 0;
+                w[12] = 0;
+                w[13] = 0;
+                w[14] = 0;
+                w[15] = 0x00000100;
+
+                SHA256ROUND(s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], 0, w[0]);
+                SHA256ROUND(s[7], s[0], s[1], s[2], s[3], s[4], s[5], s[6], 1, w[1]);
+                SHA256ROUND(s[6], s[7], s[0], s[1], s[2], s[3], s[4], s[5], 2, w[2]);
+                SHA256ROUND(s[5], s[6], s[7], s[0], s[1], s[2], s[3], s[4], 3, w[3]);
+                SHA256ROUND(s[4], s[5], s[6], s[7], s[0], s[1], s[2], s[3], 4, w[4]);
+                SHA256ROUND(s[3], s[4], s[5], s[6], s[7], s[0], s[1], s[2], 5, w[5]);
+                SHA256ROUND(s[2], s[3], s[4], s[5], s[6], s[7], s[0], s[1], 6, w[6]);
+                SHA256ROUND(s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[0], 7, w[7]);
+                SHA256ROUND(s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], 8, w[8]);
+                SHA256ROUND(s[7], s[0], s[1], s[2], s[3], s[4], s[5], s[6], 9, w[9]);
+                SHA256ROUND(s[6], s[7], s[0], s[1], s[2], s[3], s[4], s[5], 10, w[10]);
+                SHA256ROUND(s[5], s[6], s[7], s[0], s[1], s[2], s[3], s[4], 11, w[11]);
+                SHA256ROUND(s[4], s[5], s[6], s[7], s[0], s[1], s[2], s[3], 12, w[12]);
+                SHA256ROUND(s[3], s[4], s[5], s[6], s[7], s[0], s[1], s[2], 13, w[13]);
+                SHA256ROUND(s[2], s[3], s[4], s[5], s[6], s[7], s[0], s[1], 14, w[14]);
+                SHA256ROUND(s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[0], 15, w[15]);
+                w[16] = WSIGMA1(w[14]) + w[0] + w[9] + WSIGMA0(w[1]);
+                SHA256ROUND(s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], 16, w[16]);
+                w[17] = WSIGMA1(w[15]) + w[1] + w[10] + WSIGMA0(w[2]);
+                SHA256ROUND(s[7], s[0], s[1], s[2], s[3], s[4], s[5], s[6], 17, w[17]);
+                w[18] = WSIGMA1(w[16]) + w[2] + w[11] + WSIGMA0(w[3]);
+                SHA256ROUND(s[6], s[7], s[0], s[1], s[2], s[3], s[4], s[5], 18, w[18]);
+                w[19] = WSIGMA1(w[17]) + w[3] + w[12] + WSIGMA0(w[4]);
+                SHA256ROUND(s[5], s[6], s[7], s[0], s[1], s[2], s[3], s[4], 19, w[19]);
+                w[20] = WSIGMA1(w[18]) + w[4] + w[13] + WSIGMA0(w[5]);
+                SHA256ROUND(s[4], s[5], s[6], s[7], s[0], s[1], s[2], s[3], 20, w[20]);
+                w[21] = WSIGMA1(w[19]) + w[5] + w[14] + WSIGMA0(w[6]);
+                SHA256ROUND(s[3], s[4], s[5], s[6], s[7], s[0], s[1], s[2], 21, w[21]);
+                w[22] = WSIGMA1(w[20]) + w[6] + w[15] + WSIGMA0(w[7]);
+                SHA256ROUND(s[2], s[3], s[4], s[5], s[6], s[7], s[0], s[1], 22, w[22]);
+                w[23] = WSIGMA1(w[21]) + w[7] + w[16] + WSIGMA0(w[8]);
+                SHA256ROUND(s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[0], 23, w[23]);
+                w[24] = WSIGMA1(w[22]) + w[8] + w[17] + WSIGMA0(w[9]);
+                SHA256ROUND(s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], 24, w[24]);
+                w[25] = WSIGMA1(w[23]) + w[9] + w[18] + WSIGMA0(w[10]);
+                SHA256ROUND(s[7], s[0], s[1], s[2], s[3], s[4], s[5], s[6], 25, w[25]);
+                w[26] = WSIGMA1(w[24]) + w[10] + w[19] + WSIGMA0(w[11]);
+                SHA256ROUND(s[6], s[7], s[0], s[1], s[2], s[3], s[4], s[5], 26, w[26]);
+                w[27] = WSIGMA1(w[25]) + w[11] + w[20] + WSIGMA0(w[12]);
+                SHA256ROUND(s[5], s[6], s[7], s[0], s[1], s[2], s[3], s[4], 27, w[27]);
+                w[28] = WSIGMA1(w[26]) + w[12] + w[21] + WSIGMA0(w[13]);
+                SHA256ROUND(s[4], s[5], s[6], s[7], s[0], s[1], s[2], s[3], 28, w[28]);
+                w[29] = WSIGMA1(w[27]) + w[13] + w[22] + WSIGMA0(w[14]);
+                SHA256ROUND(s[3], s[4], s[5], s[6], s[7], s[0], s[1], s[2], 29, w[29]);
+                w[30] = WSIGMA1(w[28]) + w[14] + w[23] + WSIGMA0(w[15]);
+                SHA256ROUND(s[2], s[3], s[4], s[5], s[6], s[7], s[0], s[1], 30, w[30]);
+                w[31] = WSIGMA1(w[29]) + w[15] + w[24] + WSIGMA0(w[16]);
+                SHA256ROUND(s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[0], 31, w[31]);
+                w[32] = WSIGMA1(w[30]) + w[16] + w[25] + WSIGMA0(w[17]);
+                SHA256ROUND(s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], 32, w[32]);
+                w[33] = WSIGMA1(w[31]) + w[17] + w[26] + WSIGMA0(w[18]);
+                SHA256ROUND(s[7], s[0], s[1], s[2], s[3], s[4], s[5], s[6], 33, w[33]);
+                w[34] = WSIGMA1(w[32]) + w[18] + w[27] + WSIGMA0(w[19]);
+                SHA256ROUND(s[6], s[7], s[0], s[1], s[2], s[3], s[4], s[5], 34, w[34]);
+                w[35] = WSIGMA1(w[33]) + w[19] + w[28] + WSIGMA0(w[20]);
+                SHA256ROUND(s[5], s[6], s[7], s[0], s[1], s[2], s[3], s[4], 35, w[35]);
+                w[36] = WSIGMA1(w[34]) + w[20] + w[29] + WSIGMA0(w[21]);
+                SHA256ROUND(s[4], s[5], s[6], s[7], s[0], s[1], s[2], s[3], 36, w[36]);
+                w[37] = WSIGMA1(w[35]) + w[21] + w[30] + WSIGMA0(w[22]);
+                SHA256ROUND(s[3], s[4], s[5], s[6], s[7], s[0], s[1], s[2], 37, w[37]);
+                w[38] = WSIGMA1(w[36]) + w[22] + w[31] + WSIGMA0(w[23]);
+                SHA256ROUND(s[2], s[3], s[4], s[5], s[6], s[7], s[0], s[1], 38, w[38]);
+                w[39] = WSIGMA1(w[37]) + w[23] + w[32] + WSIGMA0(w[24]);
+                SHA256ROUND(s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[0], 39, w[39]);
+                w[40] = WSIGMA1(w[38]) + w[24] + w[33] + WSIGMA0(w[25]);
+                SHA256ROUND(s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], 40, w[40]);
+                w[41] = WSIGMA1(w[39]) + w[25] + w[34] + WSIGMA0(w[26]);
+                SHA256ROUND(s[7], s[0], s[1], s[2], s[3], s[4], s[5], s[6], 41, w[41]);
+                w[42] = WSIGMA1(w[40]) + w[26] + w[35] + WSIGMA0(w[27]);
+                SHA256ROUND(s[6], s[7], s[0], s[1], s[2], s[3], s[4], s[5], 42, w[42]);
+                w[43] = WSIGMA1(w[41]) + w[27] + w[36] + WSIGMA0(w[28]);
+                SHA256ROUND(s[5], s[6], s[7], s[0], s[1], s[2], s[3], s[4], 43, w[43]);
+                w[44] = WSIGMA1(w[42]) + w[28] + w[37] + WSIGMA0(w[29]);
+                SHA256ROUND(s[4], s[5], s[6], s[7], s[0], s[1], s[2], s[3], 44, w[44]);
+                w[45] = WSIGMA1(w[43]) + w[29] + w[38] + WSIGMA0(w[30]);
+                SHA256ROUND(s[3], s[4], s[5], s[6], s[7], s[0], s[1], s[2], 45, w[45]);
+                w[46] = WSIGMA1(w[44]) + w[30] + w[39] + WSIGMA0(w[31]);
+                SHA256ROUND(s[2], s[3], s[4], s[5], s[6], s[7], s[0], s[1], 46, w[46]);
+                w[47] = WSIGMA1(w[45]) + w[31] + w[40] + WSIGMA0(w[32]);
+                SHA256ROUND(s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[0], 47, w[47]);
+                w[48] = WSIGMA1(w[46]) + w[32] + w[41] + WSIGMA0(w[33]);
+                SHA256ROUND(s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], 48, w[48]);
+                w[49] = WSIGMA1(w[47]) + w[33] + w[42] + WSIGMA0(w[34]);
+                SHA256ROUND(s[7], s[0], s[1], s[2], s[3], s[4], s[5], s[6], 49, w[49]);
+                w[50] = WSIGMA1(w[48]) + w[34] + w[43] + WSIGMA0(w[35]);
+                SHA256ROUND(s[6], s[7], s[0], s[1], s[2], s[3], s[4], s[5], 50, w[50]);
+                w[51] = WSIGMA1(w[49]) + w[35] + w[44] + WSIGMA0(w[36]);
+                SHA256ROUND(s[5], s[6], s[7], s[0], s[1], s[2], s[3], s[4], 51, w[51]);
+                w[52] = WSIGMA1(w[50]) + w[36] + w[45] + WSIGMA0(w[37]);
+                SHA256ROUND(s[4], s[5], s[6], s[7], s[0], s[1], s[2], s[3], 52, w[52]);
+                w[53] = WSIGMA1(w[51]) + w[37] + w[46] + WSIGMA0(w[38]);
+                SHA256ROUND(s[3], s[4], s[5], s[6], s[7], s[0], s[1], s[2], 53, w[53]);
+                w[54] = WSIGMA1(w[52]) + w[38] + w[47] + WSIGMA0(w[39]);
+                SHA256ROUND(s[2], s[3], s[4], s[5], s[6], s[7], s[0], s[1], 54, w[54]);
+                w[55] = WSIGMA1(w[53]) + w[39] + w[48] + WSIGMA0(w[40]);
+                SHA256ROUND(s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[0], 55, w[55]);
+                w[56] = WSIGMA1(w[54]) + w[40] + w[49] + WSIGMA0(w[41]);
+                SHA256ROUND(s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], 56, w[56]);
+                w[57] = WSIGMA1(w[55]) + w[41] + w[50] + WSIGMA0(w[42]);
+                SHA256ROUND(s[7], s[0], s[1], s[2], s[3], s[4], s[5], s[6], 57, w[57]);
+                w[58] = WSIGMA1(w[56]) + w[42] + w[51] + WSIGMA0(w[43]);
+                SHA256ROUND(s[6], s[7], s[0], s[1], s[2], s[3], s[4], s[5], 58, w[58]);
+                w[59] = WSIGMA1(w[57]) + w[43] + w[52] + WSIGMA0(w[44]);
+                SHA256ROUND(s[5], s[6], s[7], s[0], s[1], s[2], s[3], s[4], 59, w[59]);
+                w[60] = WSIGMA1(w[58]) + w[44] + w[53] + WSIGMA0(w[45]);
+                SHA256ROUND(s[4], s[5], s[6], s[7], s[0], s[1], s[2], s[3], 60, w[60]);
+                w[61] = WSIGMA1(w[59]) + w[45] + w[54] + WSIGMA0(w[46]);
+                SHA256ROUND(s[3], s[4], s[5], s[6], s[7], s[0], s[1], s[2], 61, w[61]);
+                w[62] = WSIGMA1(w[60]) + w[46] + w[55] + WSIGMA0(w[47]);
+                SHA256ROUND(s[2], s[3], s[4], s[5], s[6], s[7], s[0], s[1], 62, w[62]);
+                w[63] = WSIGMA1(w[61]) + w[47] + w[56] + WSIGMA0(w[48]);
+                SHA256ROUND(s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[0], 63, w[63]);
+
+                // Feed Forward
+                s[0] = s[0] + 0x6a09e667;
+                s[1] = s[1] + 0xbb67ae85;
+                s[2] = s[2] + 0x3c6ef372;
+                s[3] = s[3] + 0xa54ff53a;
+                s[4] = s[4] + 0x510e527f;
+                s[5] = s[5] + 0x9b05688c;
+                s[6] = s[6] + 0x1f83d9ab;
+                s[7] = s[7] + 0x5be0cd19;
+
+                // Store Hash value
+                memcpy(w, s, SHA256_BLOCK_SIZE);
+            }
+
+            // Store Hash value
+            memcpy(hash, s, SHA256_BLOCK_SIZE);
+        }
+    }
+}

--- a/src/poh-simd/sha256.h
+++ b/src/poh-simd/sha256.h
@@ -1,0 +1,71 @@
+/*
+ * Adapted from kste's sha256 implementation, accessible at https://github.com/kste/sha256_avx
+ *
+ * MIT License
+ *
+ * Copyright (c) 2017
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef SHA256_H
+#define SHA256_H
+
+#define u32 unsigned int32
+#define u8 unsigned int8
+
+#define SHA256_BLOCK_SIZE 32
+
+static const u32 RC[] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+    0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+    0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+    0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+    0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+    0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+};
+
+#define MAJ(a, b, c) ((a&b) ^ (a&c) ^ (b&c))
+#define CH(a, b, c) ((a&b) ^ (~(a)&c))
+
+#define ROTR32(x, r) ((x >> r) | (x << (SHA256_BLOCK_SIZE - r)))
+
+#define SIGMA1(x) (ROTR32(x, 6) ^ ROTR32(x, 11) ^ ROTR32(x, 25))
+#define SIGMA0(x) (ROTR32(x, 2) ^ ROTR32(x, 13) ^ ROTR32(x, 22))
+
+#define WSIGMA1(x) (ROTR32(x, 17) ^ ROTR32(x, 19) ^ (x >> 10))
+#define WSIGMA0(x) (ROTR32(x, 7) ^ ROTR32(x, 18) ^ (x >> 3))
+
+#define SHA256ROUND(a, b, c, d, e, f, g, h, rc, w) \
+    T0 = h + SIGMA1(e) + CH(e, f, g) + RC[rc] + w; \
+    d = d + T0; \
+    T1 = SIGMA0(a) + MAJ(a, b, c); \
+    h = T0 + T1;
+
+#endif


### PR DESCRIPTION
The Makefile generates SIMD implementations for each of the instruction sets that ISPC supports on amd64 platforms, and gives them different names so they can be called appropriately by the solana runtime.