### PR TITLE
Add override for pubkey to be used for all packets

### DIFF
--- a/src/cuda-ecc-ed25519/ed25519.h
+++ b/src/cuda-ecc-ed25519/ed25519.h
@@ -39,7 +39,7 @@ typedef struct {
 void ED25519_DECLSPEC ed25519_create_keypair(unsigned char *public_key, unsigned char *private_key, const unsigned char *seed);
 void ED25519_DECLSPEC ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key, const unsigned char *private_key);
 int ED25519_DECLSPEC ed25519_verify(const unsigned char *signature, const unsigned char *message, uint32_t message_len, const unsigned char *public_key);
-void ED25519_DECLSPEC ed25519_verify_many(const gpu_Elems* elems, uint32_t num_elems, uint32_t message_size, uint32_t total_packets, uint32_t total_signatures, const uint32_t* message_lens, const uint32_t* public_key_offset, const uint32_t* signature_offset, const uint32_t* message_start_offset, uint8_t* out, uint8_t use_non_default_stream);
+void ED25519_DECLSPEC ed25519_verify_many(const gpu_Elems* elems, uint32_t num_elems, uint32_t message_size, uint32_t total_packets, uint32_t total_signatures, const uint32_t* message_lens, const uint32_t* public_key_offset, const uint32_t* signature_offset, const uint32_t* message_start_offset, uint8_t* out, uint8_t use_non_default_stream, const unsigned char* pubkey_override);
 void ED25519_DECLSPEC ed25519_add_scalar(unsigned char *public_key, unsigned char *private_key, const unsigned char *scalar);
 void ED25519_DECLSPEC ed25519_key_exchange(unsigned char *shared_secret, const unsigned char *public_key, const unsigned char *private_key);
 void ED25519_DECLSPEC ed25519_free_gpu_mem();

--- a/src/cuda-ecc-ed25519/main.cu
+++ b/src/cuda-ecc-ed25519/main.cu
@@ -64,7 +64,8 @@ static void* verify_proc(void* ctx) {
                             vctx->signature_offsets,
                             vctx->message_start_offsets,
                             vctx->out_h,
-                            vctx->use_non_default_stream);
+                            vctx->use_non_default_stream,
+                            NULL);
     }
     return NULL;
 }


### PR DESCRIPTION
### Problem:
Need an interface to verify many packets with the same pubkey.

### Change:
Add pubkey_override argument that takes a pointer which if it's not NULL, then the verify uses that pointer as the pubkey.