### PR TITLE
Use correct out_size for cached size instead of total_signatures.

### DIFF
--- a/src/cuda-ecc-ed25519/gpu_ctx.cu
+++ b/src/cuda-ecc-ed25519/gpu_ctx.cu
@@ -103,7 +103,7 @@ void setup_gpu_ctx(verify_ctx_t* cur_ctx,
         CUDA_CHK(cudaFree(cur_ctx->out));
         CUDA_CHK(cudaMalloc(&cur_ctx->out, out_size));
 
-        cur_ctx->out_size_bytes = total_signatures;
+        cur_ctx->out_size_bytes = out_size;
     }
 
     if (cur_ctx->public_key_offsets == NULL || cur_ctx->offsets_len < total_signatures) {


### PR DESCRIPTION
out_size_bytes was not being set correctly for the sign case