### PR TITLE
Optimize gpu sigverify

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -1,6 +1,6 @@
 steps:
   - command: "ci/build.sh"
     name: "build"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 45
     agents:
       - "queue=cuda"

--- a/src/cuda-ecc-ed25519/common.cu
+++ b/src/cuda-ecc-ed25519/common.cu
@@ -23,4 +23,19 @@ static uint64_t __host__ __device__ load_4(const unsigned char *in) {
     return result;
 }
 
+static uint64_t __host__ __device__ load_7(const unsigned char *in) {
+    uint64_t result;
+
+    result = (uint64_t) in[0];
+    result |= ((uint64_t) in[1]) << 8;
+    result |= ((uint64_t) in[2]) << 16;
+    result |= ((uint64_t) in[3]) << 24;
+    result |= ((uint64_t) in[4]) << 32;
+    result |= ((uint64_t) in[5]) << 40;
+    result |= ((uint64_t) in[6]) << 48;
+
+    return result;
+}
+
+
 #endif

--- a/src/cuda-ecc-ed25519/ed25519.h
+++ b/src/cuda-ecc-ed25519/ed25519.h
@@ -75,6 +75,10 @@ bool ED25519_DECLSPEC ed25519_init();
 int cuda_host_register(void* ptr, size_t size, unsigned int flags);
 int cuda_host_unregister(void* ptr);
 
+int ED25519_DECLSPEC ed25519_get_checked_scalar(unsigned char* out_scalar, const unsigned char* in_scalar);
+
+int ED25519_DECLSPEC ed25519_check_packed_ge_small_order(const unsigned char* packed_group_element);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/cuda-ecc-ed25519/fe.cu
+++ b/src/cuda-ecc-ed25519/fe.cu
@@ -43,6 +43,28 @@ void __device__ __host__ fe_1(fe h) {
 }
 
 
+int __host__ __device__ fe_is_1(fe h) {
+    if (h[0] != 1) {
+        return 0;
+    }
+    for (int i = 1; i < 9; i++) {
+        if (h[i] != 0) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+int __host__ __device__ fe_is_0(fe h) {
+    for (int i = 0; i < 9; i++) {
+        if (h[i] != 0) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+
 
 /*
     h = f + g

--- a/src/cuda-ecc-ed25519/fe.h
+++ b/src/cuda-ecc-ed25519/fe.h
@@ -18,6 +18,8 @@ typedef int32_t fe[10];
 
 void __host__ __device__ fe_0(fe h);
 void __device__ __host__ fe_1(fe h);
+int __device__ __host__ fe_is_0(fe h);
+int __device__ __host__ fe_is_1(fe h);
 
 void __device__ __host__ fe_frombytes(fe h, const unsigned char *s);
 void __device__ __host__ fe_tobytes(unsigned char *s, const fe h);

--- a/src/cuda-ecc-ed25519/ge.cu
+++ b/src/cuda-ecc-ed25519/ge.cu
@@ -180,6 +180,29 @@ int __device__ __host__ ge_frombytes_negate_vartime(ge_p3 *h, const unsigned cha
     return 0;
 }
 
+// x = 1, y = 0, z = 0, t = 1
+int __host__ __device__ ge_is_identity(ge_p3* p) {
+    return (fe_is_0(p->X) &&
+            fe_is_1(p->Y) &&
+            fe_is_1(p->Z) &&
+            fe_is_0(p->T)) ? 1 : 0;
+}
+
+int __host__ __device__ ge_is_small_order(ge_p3* p) {
+    ge_p1p1 r;
+    ge_p2 s;
+    ge_p3 q;
+
+    // calculate q = p * 2*3
+    ge_p3_dbl(&r, p);
+    ge_p1p1_to_p2(&s, &r);
+    ge_p2_dbl(&r, &s);
+    ge_p1p1_to_p2(&s, &r);
+    ge_p2_dbl(&r, &s);
+    ge_p1p1_to_p3(&q, &r);
+
+    return ge_is_identity(&q);
+}
 
 /*
 r = p + q

--- a/src/cuda-ecc-ed25519/int128.h
+++ b/src/cuda-ecc-ed25519/int128.h
@@ -1,0 +1,37 @@
+#ifndef INT128_H
+#define INT128_H
+
+struct uint128_t {
+  uint64_t low;
+  uint64_t high;
+};
+
+static __device__ __host__ uint128_t mul_128(uint64_t a, uint64_t b) {
+  uint128_t result;
+#ifdef __CUDA_ARCH__
+  result.low = a * b;
+  result.high = __mul64hi(a, b);
+#elif __x86_64__
+  asm( "mulq %3\n\t"
+      : "=a" (result.low), "=d" (result.high)
+      : "%0" (a), "rm" (b));
+#endif
+  return result;
+}
+
+static __device__ __host__ uint128_t add_128(uint128_t a, uint128_t b) {
+  uint128_t result;
+#ifdef __CUDA_ARCH__
+  asm( "add.cc.u64    %0, %2, %4;\n\t"
+       "addc.u64      %1, %3, %5;\n\t"
+       : "=l" (result.low), "=l" (result.high)
+       : "l" (a.low), "l" (a.high),
+       "l" (b.low), "l" (b.high));
+#else
+  result.low = a.low + b.low;
+  result.high = a.high + b.high + (result.low < a.low);
+#endif
+  return result;
+}
+
+#endif

--- a/src/cuda-ecc-ed25519/license.txt
+++ b/src/cuda-ecc-ed25519/license.txt
@@ -14,3 +14,34 @@ applications, and to alter it and redistribute it freely, subject to the followi
    being the original software.
 
 3. This notice may not be removed or altered from any source distribution.
+
+================================
+
+Copyright (c) 2017-2019 isis agora lovecruft. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/cuda-ecc-ed25519/sc.h
+++ b/src/cuda-ecc-ed25519/sc.h
@@ -6,6 +6,7 @@ The set of scalars is \Z/l
 where l = 2^252 + 27742317777372353535851937790883648493.
 */
 
+void __host__ __device__ scalar32_reduce(unsigned char* s);
 void __host__ __device__ sc_reduce(unsigned char *s);
 void __host__ __device__ sc_muladd(unsigned char *s, const unsigned char *a, const unsigned char *b, const unsigned char *c);
 

--- a/src/cuda-ecc-ed25519/verify.cu
+++ b/src/cuda-ecc-ed25519/verify.cu
@@ -56,6 +56,56 @@ static int __host__ __device__ consttime_equal(const unsigned char *x, const uns
     return !r;
 }
 
+// 0 == success
+static int __host__ __device__
+get_checked_scalar(unsigned char* scalar, const unsigned char* signature) {
+    // Check if top 4-bits are clear
+    // then scalar is reduced.
+    if ((signature[31] & 0xf0) == 0) {
+        for (int i = 0; i < 32; i++) {
+            scalar[i] = signature[i];
+        }
+        return 0;
+    }
+
+    if ((signature[31] >> 7) != 0) {
+        return 1;
+    }
+
+    scalar32_reduce(scalar);
+    if (!consttime_equal(scalar, signature)) {
+        return 1;
+    }
+    return 0;
+
+}
+
+int ed25519_get_checked_scalar(unsigned char* out_scalar, const unsigned char* in_scalar) {
+    return get_checked_scalar(out_scalar, in_scalar);
+}
+
+// Return 0=success if ge unpacks and is not small order
+static int __device__ __host__
+check_packed_ge_small_order(const unsigned char* packed_group_element) {
+    ge_p3 signature_R;
+
+    // fail if ge does not unpack
+    if (0 != ge_frombytes_negate_vartime(&signature_R, packed_group_element)) {
+        return 1;
+    }
+
+    // fail if ge is small order
+    if (0 != ge_is_small_order(&signature_R)) {
+        return 1;
+    }
+
+    return 0;
+}
+
+int ed25519_check_packed_ge_small_order(const unsigned char* packed_group_element) {
+    return check_packed_ge_small_order(packed_group_element);
+}
+
 static int __device__ __host__
 ed25519_verify_device(const unsigned char *signature,
                       const unsigned char *message,
@@ -67,11 +117,16 @@ ed25519_verify_device(const unsigned char *signature,
     ge_p3 A;
     ge_p2 R;
 
-    if (signature[63] & 224) {
+    // Check that s.reduce() == s
+    if (0 != get_checked_scalar(checker, signature + 32)) {
         return 0;
     }
 
-    if (ge_frombytes_negate_vartime(&A, public_key) != 0) {
+    if (0 != check_packed_ge_small_order(signature)) {
+        return 0;
+    }
+
+    if (0 != ge_frombytes_negate_vartime(&A, public_key)) {
         return 0;
     }
 

--- a/src/gpu-common.mk
+++ b/src/gpu-common.mk
@@ -3,6 +3,7 @@ GPU_PTX_ARCH:=compute_35
 GPU_ARCHS?=sm_37,sm_50,sm_61,sm_70
 HOST_CFLAGS:=-Wall -Werror -fPIC -Wno-strict-aliasing
 GPU_CFLAGS:=--gpu-code=$(GPU_ARCHS),$(GPU_PTX_ARCH) --gpu-architecture=$(GPU_PTX_ARCH)
-CFLAGS_release:=-Icommon --ptxas-options=-v $(GPU_CFLAGS) -O3 -Xcompiler "$(HOST_CFLAGS)"
+#--ptxas-options=-v
+CFLAGS_release:=-Icommon $(GPU_CFLAGS) -O3 -Xcompiler "$(HOST_CFLAGS)"
 CFLAGS_debug:=$(CFLAGS_release) -g
 CFLAGS:=$(CFLAGS_$V)


### PR DESCRIPTION
Check that `s` in signature is fully reduced (`s.reduce() == s`). Check that `signature_R` unpacks as a group element and that it is of small order.

Tests in solana-labs/solana repo.
https://github.com/solana-labs/solana/pull/9870