### PR TITLE
Fe opt split kernels and optimize divergence

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -1,6 +1,6 @@
 steps:
   - command: "ci/build.sh"
     name: "build"
-    timeout_in_minutes: 45
+    timeout_in_minutes: 120
     agents:
       - "queue=cuda"

--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -1,6 +1,6 @@
 steps:
   - command: "ci/build.sh"
     name: "build"
-    timeout_in_minutes: 120
+    timeout_in_minutes: 35
     agents:
       - "queue=cuda"

--- a/src/cuda-ecc-ed25519/ed25519.h
+++ b/src/cuda-ecc-ed25519/ed25519.h
@@ -25,6 +25,7 @@ extern "C" {
 int ED25519_DECLSPEC ed25519_create_seed(unsigned char *seed);
 #endif
 
+#define SHA512_SIZE 64
 #define PUB_KEY_SIZE 32
 #define PRIV_KEY_SIZE 64
 #define SEED_SIZE 32

--- a/src/cuda-ecc-ed25519/ge.h
+++ b/src/cuda-ecc-ed25519/ge.h
@@ -51,6 +51,8 @@ typedef struct {
   fe T2d;
 } ge_cached;
 
+#define GE_LOOKUP_SIZE 8
+
 void __host__ __device__ ge_p3_tobytes(unsigned char *s, const ge_p3 *h);
 void __host__ __device__ ge_tobytes(unsigned char *s, const ge_p2 *h);
 int  __host__ __device__ ge_frombytes_negate_vartime(ge_p3 *h, const unsigned char *s);
@@ -58,7 +60,7 @@ int  __host__ __device__ ge_frombytes_negate_vartime(ge_p3 *h, const unsigned ch
 void __host__ __device__ ge_add(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q);
 void __host__ __device__ ge_sub(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q);
 void __host__ __device__ ge_addsub(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q, bool add);
-void __host__ __device__ ge_double_scalarmult_vartime(ge_p2 *r, const unsigned char *a, const ge_p3 *A, const unsigned char *b);
+void __host__ __device__ ge_double_scalarmult_vartime(ge_p2 *r, const unsigned char *a, const ge_cached *A, const unsigned char *b);
 void __host__ __device__ ge_madd(ge_p1p1 *r, const ge_p3 *p, const ge_precomp *q);
 void __host__ __device__ ge_msub(ge_p1p1 *r, const ge_p3 *p, const ge_precomp *q);
 void __host__ __device__ ge_maddsub(ge_p1p1 *r, const ge_p3 *p, const ge_precomp *q, bool add);

--- a/src/cuda-ecc-ed25519/ge.h
+++ b/src/cuda-ecc-ed25519/ge.h
@@ -57,9 +57,11 @@ int  __host__ __device__ ge_frombytes_negate_vartime(ge_p3 *h, const unsigned ch
 
 void __host__ __device__ ge_add(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q);
 void __host__ __device__ ge_sub(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q);
+void __host__ __device__ ge_addsub(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q, bool add);
 void __host__ __device__ ge_double_scalarmult_vartime(ge_p2 *r, const unsigned char *a, const ge_p3 *A, const unsigned char *b);
 void __host__ __device__ ge_madd(ge_p1p1 *r, const ge_p3 *p, const ge_precomp *q);
 void __host__ __device__ ge_msub(ge_p1p1 *r, const ge_p3 *p, const ge_precomp *q);
+void __host__ __device__ ge_maddsub(ge_p1p1 *r, const ge_p3 *p, const ge_precomp *q, bool add);
 void __host__ __device__ ge_scalarmult_base(ge_p3 *h, const unsigned char *a);
 
 void __host__ __device__ ge_p1p1_to_p2(ge_p2 *r, const ge_p1p1 *p);

--- a/src/cuda-ecc-ed25519/gpu_ctx.cu
+++ b/src/cuda-ecc-ed25519/gpu_ctx.cu
@@ -107,6 +107,12 @@ void setup_gpu_ctx(verify_ctx_t* cur_ctx,
     }
 
     if (cur_ctx->public_key_offsets == NULL || cur_ctx->offsets_len < total_signatures) {
+        CUDA_CHK(cudaFree(cur_ctx->Ai));
+        CUDA_CHK(cudaMalloc(&cur_ctx->Ai, total_signatures * sizeof(ge_cached) * GE_LOOKUP_SIZE));
+
+        CUDA_CHK(cudaFree(cur_ctx->h));
+        CUDA_CHK(cudaMalloc(&cur_ctx->h, total_signatures * SHA512_SIZE));
+
         CUDA_CHK(cudaFree(cur_ctx->public_key_offsets));
         CUDA_CHK(cudaMalloc(&cur_ctx->public_key_offsets, offsets_size));
 

--- a/src/cuda-ecc-ed25519/gpu_ctx.h
+++ b/src/cuda-ecc-ed25519/gpu_ctx.h
@@ -3,6 +3,7 @@
 
 #include <inttypes.h>
 #include "ed25519.h"
+#include "ge.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +13,8 @@ typedef struct {
     uint8_t* packets;
     uint32_t packets_size_bytes;
 
+    ge_cached* Ai;
+    uint8_t* h;
     uint8_t* out;
     size_t out_size_bytes;
 

--- a/src/gpu-common.mk
+++ b/src/gpu-common.mk
@@ -3,7 +3,13 @@ GPU_PTX_ARCH:=compute_35
 GPU_ARCHS?=sm_37,sm_50,sm_61,sm_70
 HOST_CFLAGS:=-Wall -Werror -fPIC -Wno-strict-aliasing
 GPU_CFLAGS:=--gpu-code=$(GPU_ARCHS),$(GPU_PTX_ARCH) --gpu-architecture=$(GPU_PTX_ARCH)
-#--ptxas-options=-v
+
+# enable for profiling
+#GPU_CFLAGS+=-lineinfo
+
+# enable to see kernel register stats
+#GPU_CFLAGS+=--ptxas-options=-v
+
 CFLAGS_release:=-Icommon $(GPU_CFLAGS) -O3 -Xcompiler "$(HOST_CFLAGS)"
 CFLAGS_debug:=$(CFLAGS_release) -g
 CFLAGS:=$(CFLAGS_$V)

--- a/src/opencl-ecc-ed25519/main.cpp
+++ b/src/opencl-ecc-ed25519/main.cpp
@@ -9,6 +9,8 @@
 #include <pthread.h>
 #include "gpu_common.h"
 #include "gpu_ctx.h"
+#include "seed.cu"
+#include "keypair.cu"
 
 #define USE_CLOCK_GETTIME
 #include "perftime.h"

--- a/src/opencl-ecc-ed25519/verify.cpp
+++ b/src/opencl-ecc-ed25519/verify.cpp
@@ -6,8 +6,6 @@
 #include "ge.cu"
 #include "sc.cu"
 #include "fe.cu"
-#include "seed.cu"
-#include "keypair.cu"
 #include "sha512.cu"
 
 #include "ed25519.h"
@@ -67,16 +65,12 @@ static int ed25519_verify_device(const unsigned char *signature,
     unsigned char h[64];
     unsigned char checker[32];
     sha512_context hash;
-    ge_p3 A;
     ge_p2 R;
 
     if (signature[63] & 224) {
         return 0;
     }
 
-    if (ge_frombytes_negate_vartime(&A, public_key) != 0) {
-        return 0;
-    }
     sha512_init(&hash);
     sha512_update(&hash, signature, 32);
     sha512_update(&hash, public_key, 32);
@@ -84,7 +78,11 @@ static int ed25519_verify_device(const unsigned char *signature,
     sha512_final(&hash, h);
     
     sc_reduce(h);
-    ge_double_scalarmult_vartime(&R, h, &A, signature + 32);
+    ge_cached Ai[8];
+    if (0 != ge_gen_lookup(public_key, Ai)) {
+        return 0;
+    }
+    ge_double_scalarmult_vartime(&R, h, Ai, signature + 32);
     ge_tobytes(checker, &R);
 
     if (!consttime_equal(checker, signature)) {


### PR DESCRIPTION
Optimize divergence in the ge_double_scalarmult critical loop by combining the group operations in the cases where the slide is doing add or subtract since they use largely the same code except for some different pointers and a couple different fe_add/fe_sub.

Above optimization caused extreme compile times probably due to more inlining and giving the optimizer more options for register scheduling. Split the verify operations into 1. sha of message+scalar reduce 2. lookup table generation for double_scalarmult and 3. double_scalarmult operation.

Gives ~2x speedup on 2080ti.