### PR TITLE
Add specific kernel compiles for Nvidia Turing and Ampere GPU microarchitectures

### DIFF
--- a/src/gpu-common.mk
+++ b/src/gpu-common.mk
@@ -1,6 +1,6 @@
 NVCC:=nvcc
 GPU_PTX_ARCH:=compute_35
-GPU_ARCHS?=sm_37,sm_50,sm_61,sm_70,sm_75,sm_80
+GPU_ARCHS?=sm_61,sm_70,sm_75,sm_80
 HOST_CFLAGS:=-Wall -Werror -fPIC -Wno-strict-aliasing
 GPU_CFLAGS:=--gpu-code=$(GPU_ARCHS),$(GPU_PTX_ARCH) --gpu-architecture=$(GPU_PTX_ARCH)
 

--- a/src/gpu-common.mk
+++ b/src/gpu-common.mk
@@ -1,6 +1,6 @@
 NVCC:=nvcc
 GPU_PTX_ARCH:=compute_35
-GPU_ARCHS?=sm_37,sm_50,sm_61,sm_70
+GPU_ARCHS?=sm_37,sm_50,sm_61,sm_70,sm_75,sm_80
 HOST_CFLAGS:=-Wall -Werror -fPIC -Wno-strict-aliasing
 GPU_CFLAGS:=--gpu-code=$(GPU_ARCHS),$(GPU_PTX_ARCH) --gpu-architecture=$(GPU_PTX_ARCH)
 

--- a/src/gpu-common.mk
+++ b/src/gpu-common.mk
@@ -1,6 +1,6 @@
 NVCC:=nvcc
 GPU_PTX_ARCH:=compute_35
-GPU_ARCHS?=sm_61,sm_70,sm_75,sm_80
+GPU_ARCHS?=sm_61,sm_70,sm_75,sm_80,sm_86
 HOST_CFLAGS:=-Wall -Werror -fPIC -Wno-strict-aliasing
 GPU_CFLAGS:=--gpu-code=$(GPU_ARCHS),$(GPU_PTX_ARCH) --gpu-architecture=$(GPU_PTX_ARCH)
 


### PR DESCRIPTION
Should hopefully improve performance on Turing and Ampere cards by including kernel compiles specifically for them instead of having to fall back on PTX