### PR TITLE
Pass GPU_CFLAGS to CUDA linker

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -135,7 +135,7 @@ $V/crypt-dlink.o: $(CPU_GPU_OBJS)
 	$(NVCC) -Xcompiler "-fPIC" $(CFLAGS) --device-link $^ --output-file $@
 
 $V/lib$(LIB).so: $V/crypt-dlink.o $(CPU_GPU_OBJS)
-	$(NVCC) -Xcompiler "-fPIC" --shared --output-file $@ $^
+	$(NVCC) -Xcompiler "-fPIC" $(GPU_CFLAGS) --shared --output-file $@ $^
 
 $V/ecc_main.o: $(addprefix $(ECC_DIR)/,main.cu ed25519.h)
 	@mkdir -p $(@D)


### PR DESCRIPTION
Currently `GPU_CFLAGS`  (containing `--gpu-code` and `--gpu-architecture`) are being passed to `nvcc` during compilation, but not when producing the shared object (`.so`) library. As a result, `nvcc`'s defaults are being used, which may or may not match what the object (`.o`) files may contain, depending on the CUDA version used. In case of a mismatch, warnings are generated.

A safe way to avoid the mismatch is to always link with the same `GPU_CPLAGS` as used during compilation.

Example warnings on CUDA-11.2 when `GPU_ARCHS:=sm_61` and `GPU_PTX_ARCH:=compute_61`:
```
nvcc -Xcompiler "-fPIC" --shared --output-file release/libcuda-crypt.so release/crypt-dlink.o release/verify.o release/poh_verify.o release/gpu_ctx.o release/sign.o release/seed.o release/keypair.o
nvlink warning : SM Arch ('sm_52') not found in 'release/verify.o'
nvlink warning : SM Arch ('sm_52') not found in 'release/poh_verify.o'
nvlink warning : SM Arch ('sm_52') not found in 'release/gpu_ctx.o'
nvlink warning : SM Arch ('sm_52') not found in 'release/sign.o'
nvlink warning : SM Arch ('sm_52') not found in 'release/seed.o'
nvlink warning : SM Arch ('sm_52') not found in 'release/keypair.o'
```

This PR adds `$(GPU_CFLAGS)` to `nvcc` parameters used in the linking phase.