### PR TITLE
opencl: Fix build error

### DIFF
--- a/src/opencl-platform/cl_init_platform.cpp
+++ b/src/opencl-platform/cl_init_platform.cpp
@@ -151,7 +151,7 @@ void cl_get_compiler_err_log(cl_program program, cl_device_id device)
     build_log[ log_size ] = '\0';
     cout << endl << build_log << endl;
 	
-	delete build_log;
+	delete[] build_log;
 }
 
 /**


### PR DESCRIPTION
#### Problem

Building with a newer nvcc with the default errors enabled, the current opencl build errors with:

```
opencl-platform/cl_init_platform.cpp: In function ‘void cl_get_compiler_err_log(cl_program, cl_device_id)’:
opencl-platform/cl_init_platform.cpp:154:16: error: ‘void operator delete(void*)’ called on pointer returned from a mismatched allocation function [-Werror=mismatched-new-delete]
  154 |         delete build_log;
      |                ^~~~~~~~~
opencl-platform/cl_init_platform.cpp:146:40: note: returned from ‘void* operator new [](std::size_t)’
  146 |     build_log = new char[ log_size + 1 ];
      |                                        ^
```

#### Solution

Use `delete[]` instead of `delete`